### PR TITLE
feat: add ApiModel and ApiModelProperty decorator

### DIFF
--- a/src/lib/swagger-express-ts/api-model-property.decorator.ts
+++ b/src/lib/swagger-express-ts/api-model-property.decorator.ts
@@ -1,0 +1,17 @@
+import { SwaggerService } from "./swagger.service";
+import { IApiOperationArgsBase } from "./i-api-operation-args.base";
+
+export interface IApiModelPropertyArgs {
+  required? : boolean
+  format?: string;
+  type?: string;
+  description?: string;
+  enum?: string[];
+}
+
+export function ApiModelProperty(args?: IApiModelPropertyArgs): PropertyDecorator {
+  return function (target: any, propertyKey: string | symbol) {
+    const propertyType = Reflect.getMetadata("design:type", target, propertyKey).name.toLowerCase();
+    SwaggerService.getInstance().addApiModelProperty(args, target, propertyKey, propertyType);
+  };
+}

--- a/src/lib/swagger-express-ts/api-model.decorator.ts
+++ b/src/lib/swagger-express-ts/api-model.decorator.ts
@@ -1,0 +1,12 @@
+import { SwaggerService } from "./swagger.service";
+import { IApiOperationArgsBase } from "./i-api-operation-args.base";
+
+export interface IApiModelArgs {
+  description?: string;
+}
+
+export function ApiModel(args?: IApiModelArgs): ClassDecorator {
+  return function (target: any) {
+    SwaggerService.getInstance().addApiModel(args, target);
+  };
+}

--- a/src/lib/swagger-express-ts/i-swagger.ts
+++ b/src/lib/swagger-express-ts/i-swagger.ts
@@ -88,6 +88,9 @@ export interface ISwaggerPath {
 export interface ISwaggerDefinitionProperty {
     type: string; // Example : SwaggerDefinition.Definition.Property.Type.INTEGER
     format?: string; // Example : SwaggerDefinition.Definition.Property.Format.INT_64
+    required?: boolean;
+    description?: string;
+    enum?: string[];
 }
 
 export interface ISwaggerDefinitionXML {
@@ -99,6 +102,7 @@ export interface ISwaggerDefinition {
     required?: string[];
     properties: {[key: string]: ISwaggerDefinitionProperty},
     xml?: ISwaggerDefinitionXML;
+    description?: string;
 }
 
 export interface ISwagger {

--- a/src/lib/swagger-express-ts/index.ts
+++ b/src/lib/swagger-express-ts/index.ts
@@ -1,9 +1,15 @@
+import 'reflect-metadata';
+
 export { IApiPathArgs, ApiPath } from "./api-path.decorator";
 export { IApiOperationGetArgs, ApiOperationGet } from "./api-operation-get.decorator";
 export { IApiOperationPostArgs, ApiOperationPost } from "./api-operation-post.decorator";
 export { IApiOperationPutArgs, ApiOperationPut } from "./api-operation-put.decorator";
 export { IApiOperationPatchArgs, ApiOperationPatch } from "./api-operation-patch.decorator";
 export { IApiOperationDeleteArgs, ApiOperationDelete } from "./api-operation-delete.decorator";
+
+export { IApiModelPropertyArgs, ApiModelProperty } from "./api-model-property.decorator";
+export { IApiModelArgs, ApiModel } from "./api-model.decorator";
+
 export { SwaggerDefinitionConstant } from "./swagger-definition.constant";
 export { express, ISwaggerExpressOptions } from "./express.configurator";
 export { build } from "./swagger.builder";

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,9 @@ import { interfaces, InversifyExpressServer, TYPE } from "inversify-express-util
 import { VersionController } from "./version/version.controller";
 import * as swagger from "./lib/swagger-express-ts";
 import { SwaggerDefinitionConstant } from "./lib/swagger-express-ts";
-const config = require( "../config.json" );
+const config = require("../config.json");
+
+import './version/version.model';
 
 // set up container
 const container = new Container();
@@ -28,26 +30,6 @@ server.setConfig( ( app: any ) => {
                 info : {
                     title : "My api",
                     version : "1.0"
-                },
-                models : {
-                    Version : {
-                        properties : {
-                            id : {
-                                type : SwaggerDefinitionConstant.Model.Property.Type.STRING,
-                                required : true
-                            },
-                            name : {
-                                type : SwaggerDefinitionConstant.Model.Property.Type.STRING,
-                                required : true
-                            },
-                            description : {
-                                type : SwaggerDefinitionConstant.Model.Property.Type.STRING
-                            },
-                            version : {
-                                type : SwaggerDefinitionConstant.Model.Property.Type.STRING
-                            }
-                        }
-                    }
                 },
                 externalDocs : {
                     url : "My url"

--- a/src/version/version.controller.ts
+++ b/src/version/version.controller.ts
@@ -6,133 +6,132 @@ import "reflect-metadata";
 import { SwaggerDefinitionConstant } from "../lib/swagger-express-ts/swagger-definition.constant";
 import { ApiOperationPut } from "../lib/swagger-express-ts/api-operation-put.decorator";
 
-@ApiPath( {
-    path : "/versions",
-    name : "Version",
-    security : { basicAuth : [] }
-} )
-@controller( "/versions" )
+@ApiPath({
+    path: "/versions",
+    name: "Version",
+    security: { basicAuth: [] }
+})
+@controller("/versions")
 @injectable()
 export class VersionController implements interfaces.Controller {
     public static TARGET_NAME: string = "VersionController";
-    private data: [any] = [
-        {
-            id : "1",
-            name : "Version 1",
-            description : "Description Version 1",
-            version : "1.0.0"
+    
+    private data = [{
+            id: "1",
+            name: "Version 1",
+            description: "Description Version 1",
+            version: "1.0.0"
         },
         {
-            id : "2",
-            name : "Version 2",
-            description : "Description Version 2",
-            version : "2.0.0"
-        }
-    ];
+            id: "2",
+            name: "Version 2",
+            description: "Description Version 2",
+            version: "2.0.0"
+        }];
 
-    @ApiOperationGet( {
-        description : "Get versions objects list",
-        summary : "Get versions list",
-        responses : {
-            200 : { description : "Success", isArray : true, model : "Version" }
+    @ApiOperationGet({
+        description: "Get versions objects list",
+        summary: "Get versions list",
+        responses: {
+            200: { description: "Success", isArray: true, model: "Version" }
         },
-        security : {
-            apiKeyHeader : []
+        security: {
+            apiKeyHeader: []
         },
         deprecated: true
-    } )
-    @httpGet( "/" )
-    public getVersions( request: express.Request, response: express.Response, next: express.NextFunction ): void {
-        response.json( this.data );
+    })
+    @httpGet("/")
+    public getVersions(request: express.Request, response: express.Response, next: express.NextFunction): void {
+        response.json(this.data);
     }
 
-    @ApiOperationPost( {
-        description : "Post version object",
-        summary : "Post new version",
-        parameters : {
-            body : { description : "New version", required : true, model : "Version" }
+    @ApiOperationPost({
+        description: "Post version object",
+        summary: "Post new version",
+        parameters: {
+            body: { description: "New version", required: true, model: "Version" }
         },
-        responses : {
-            200 : { description : "Success" },
-            400 : { description : "Parameters fail" }
+        responses: {
+            200: { description: "Success" },
+            400: { description: "Parameters fail" }
         }
-    } )
-    @httpPost( "/" )
-    public postVersion( request: express.Request, response: express.Response, next: express.NextFunction ): void {
-        if ( ! request.body ) {
-            return response.status( 400 ).end();
+    })
+    @httpPost("/")
+    public postVersion(request: express.Request, response: express.Response, next: express.NextFunction): void {
+        if (!request.body) {
+            return response.status(400).end();
         }
-        this.data.push( request.body );
-        response.json( request.body );
+        this.data.push(request.body);
+        response.json(request.body);
     }
 
-    @ApiOperationGet( {
-        path : "/{id}",
-        description : "Get version by id",
-        summary : "Get version detail",
-        parameters : {
-            path : {
-                id : {
-                    description : "Id of version",
-                    type : SwaggerDefinitionConstant.Parameter.Type.STRING,
-                    required : true
+    @ApiOperationGet({
+        path: "/{id}",
+        description: "Get version by id",
+        summary: "Get version detail",
+        parameters: {
+            path: {
+                id: {
+                    description: "Id of version",
+                    type: SwaggerDefinitionConstant.Parameter.Type.STRING,
+                    required: true
                 }
             }
         },
-        responses : {
-            200 : { description : "Success", model : "Version" },
-            404 : { description : "Version not exist" }
+        responses: {
+            200: { description: "Success", model: "Version" },
+            404: { description: "Version not exist" }
         },
-        produces : [ SwaggerDefinitionConstant.Produce.JSON ]
-    } )
-    @httpGet( "/:id" )
-    public getVersion( @requestParam( "id" ) id: string, request: express.Request, response: express.Response, next: express.NextFunction ): void {
-        this.data.forEach( ( version: any )=> {
-            if ( version.id === id ) {
-                return response.json( version );
+        produces: [SwaggerDefinitionConstant.Produce.JSON]
+    })
+    @httpGet("/:id")
+    public getVersion(@requestParam("id") id: string, request: express.Request, response: express.Response, next: express.NextFunction): void {
+        this.data.forEach((version: any) => {
+            if (version.id === id) {
+                return response.json(version);
             }
-        } );
-        response.status( 404 ).end();
+        });
+        response.status(404).end();
     }
 
-    @ApiOperationPut( {
-        path : "/{id}",
-        description : "Put version by id",
-        summary : "Put version",
-        parameters : {
-            path : {
-                id : {
-                    description : "Id of version",
-                    type : SwaggerDefinitionConstant.Parameter.Type.STRING,
-                    required : true
+    @ApiOperationPut({
+        path: "/{id}",
+        description: "Put version by id",
+        summary: "Put version",
+        parameters: {
+            path: {
+                id: {
+                    description: "Id of version",
+                    type: SwaggerDefinitionConstant.Parameter.Type.STRING,
+                    required: true
                 }
             },
-            body : {
-                description : "Updated version",
-                model : "Version",
-                required : true
+            body: {
+                description: "Updated version",
+                model: "Version",
+                required: true
             }
         },
-        responses : {
-            200 : { model : "Version" }
+        responses: {
+            200: { model: "Version" }
         }
-    } )
-    @httpPut( "/:id" )
-    public putVersion( @requestParam( "id" ) id: string, request: express.Request, response: express.Response, next: express.NextFunction ): void {
-        if ( ! request.body ) {
-            return response.status( 400 ).end();
+    })
+    @httpPut("/:id")
+    public putVersion(@requestParam("id") id: string, request: express.Request, response: express.Response, next: express.NextFunction): void {
+        if (!request.body) {
+            return response.status(400).end();
         }
-        this.data.forEach( ( version: any, index: number )=> {
-            if ( version.id === id ) {
+        this.data.forEach((version: any, index: number) => {
+            if (version.id === id) {
                 let newVersion = request.body;
                 version.id = newVersion.id;
                 version.name = newVersion.name;
                 version.description = newVersion.description;
                 version.version = newVersion.version;
-                this.data[ index ] = version;
-                return response.json( version );
+                this.data[index] = version;
+                return response.json(version);
             }
-        } );
-        response.status( 404 ).end();
+        });
+        response.status(404).end();
     }
 }

--- a/src/version/version.model.ts
+++ b/src/version/version.model.ts
@@ -1,0 +1,19 @@
+import { ApiModel, ApiModelProperty } from "../lib/swagger-express-ts";
+
+
+@ApiModel({
+  description: "Version description"
+})
+export class Version {
+
+  @ApiModelProperty({
+    description: "number value",
+    enum : ['1', '2']
+  })
+  number: number;
+
+  @ApiModelProperty({
+    required: true
+  })
+  description: string;
+}


### PR DESCRIPTION
Here is "base" working version of apiModel et ApiModelProperty decorator

 We can still manage the model through the old way + the new thanks to a merge on the setDefinition function.

To make the @ApiModel and @ApiModelPropertyWork we need to require every model file before the swagger build.

* I had some problem on vscode for debug cause of the sourcemap (dunno why yet)
* You/we should create an editorconfig file at the root of the project to manage code formatting http://editorconfig.org/