### PR TITLE
Adding support for $ref and items.$ref in the definition object

### DIFF
--- a/src/lib/swagger-express-ts/i-swagger.ts
+++ b/src/lib/swagger-express-ts/i-swagger.ts
@@ -88,6 +88,7 @@ export interface ISwaggerPath {
 export interface ISwaggerDefinitionProperty {
     type: string; // Example : SwaggerDefinition.Definition.Property.Type.INTEGER
     format?: string; // Example : SwaggerDefinition.Definition.Property.Format.INT_64
+    $ref?: string;
 }
 
 export interface ISwaggerDefinitionXML {

--- a/src/lib/swagger-express-ts/i-swagger.ts
+++ b/src/lib/swagger-express-ts/i-swagger.ts
@@ -1,4 +1,4 @@
-import { ISwaggerSecurityDefinition } from "./swagger.builder";
+import { ISwaggerSecurityDefinition, ISwaggerBuildDefinitionModelPropertyItems } from "./swagger.builder";
 export interface ISwaggerLicense {
     name: string;
     url?: string;
@@ -88,6 +88,7 @@ export interface ISwaggerPath {
 export interface ISwaggerDefinitionProperty {
     type: string; // Example : SwaggerDefinition.Definition.Property.Type.INTEGER
     format?: string; // Example : SwaggerDefinition.Definition.Property.Format.INT_64
+    items?: ISwaggerBuildDefinitionModelPropertyItems;
     $ref?: string;
 }
 

--- a/src/lib/swagger-express-ts/swagger.builder.ts
+++ b/src/lib/swagger-express-ts/swagger.builder.ts
@@ -27,6 +27,22 @@ export interface ISwaggerBuildDefinitionModelProperty {
      * Optional.
      */
     $ref?: string;
+
+    /**
+     * Define to reference another model.
+     * i.e. '#/definitions/User'
+     * Optional.
+     */
+    items?: ISwaggerBuildDefinitionModelPropertyItems;
+
+}
+export interface ISwaggerBuildDefinitionModelPropertyItems {
+    /**
+     * Define to reference another model.
+     * i.e. '#/definitions/User'
+     * Optional.
+     */
+    $ref?: string;
 }
 
 export interface ISwaggerBuildDefinitionModel {
@@ -163,11 +179,14 @@ export function build( buildDefinition: ISwaggerBuildDefinition ): void {
                 if ( property.format ) {
                     newProperty.format = property.format;
                 }
+                if ( property.required ) {
+                    newDefinition.required.push( propertyIndex );
+                }
                 if ( property.$ref ) {
                     newProperty.$ref = property.$ref;
                 }
-                if ( property.required ) {
-                    newDefinition.required.push( propertyIndex );
+                if ( property.items ) {
+                    newProperty.items = property.items;
                 }
                 newDefinition.properties[ propertyIndex ] = newProperty;
             }

--- a/src/lib/swagger-express-ts/swagger.builder.ts
+++ b/src/lib/swagger-express-ts/swagger.builder.ts
@@ -26,7 +26,7 @@ export interface ISwaggerBuildDefinitionModelProperty {
      * i.e. '#/definitions/User'
      * Optional.
      */
-    $ref?: boolean;
+    $ref?: string;
 }
 
 export interface ISwaggerBuildDefinitionModel {
@@ -162,6 +162,9 @@ export function build( buildDefinition: ISwaggerBuildDefinition ): void {
                 };
                 if ( property.format ) {
                     newProperty.format = property.format;
+                }
+                if ( property.$ref ) {
+                    newProperty.$ref = property.$ref;
                 }
                 if ( property.required ) {
                     newDefinition.required.push( propertyIndex );

--- a/src/lib/swagger-express-ts/swagger.builder.ts
+++ b/src/lib/swagger-express-ts/swagger.builder.ts
@@ -7,7 +7,7 @@ export interface ISwaggerBuildDefinitionModelProperty {
     /**
      * Define type of property. Example: SwaggerDefinitionConstant.Definition.Property.Type.STRING
      */
-        type: string;
+    type: string;
 
     /**
      * Define format of property. Example: SwaggerDefinitionConstant.Definition.Property.Format.INT_64
@@ -20,6 +20,13 @@ export interface ISwaggerBuildDefinitionModelProperty {
      * Optional. Default is false.
      */
     required?: boolean;
+
+    /**
+     * Define to reference another model.
+     * i.e. '#/definitions/User'
+     * Optional.
+     */
+    $ref?: boolean;
 }
 
 export interface ISwaggerBuildDefinitionModel {

--- a/src/version/version.controller.ts
+++ b/src/version/version.controller.ts
@@ -15,7 +15,7 @@ import { ApiOperationPut } from "../lib/swagger-express-ts/api-operation-put.dec
 @injectable()
 export class VersionController implements interfaces.Controller {
     public static TARGET_NAME: string = "VersionController";
-    private data: [any] = [
+    private data: any[] = [
         {
             id : "1",
             name : "Version 1",

--- a/wiki/installation.md
+++ b/wiki/installation.md
@@ -6,8 +6,7 @@ You can get the latest release and the type setDefinitions using npm:
 npm install swagger-express-ts reflect-metadata --save
 ```
 
-The InversifyJS type setDefinitions are included in the inversify npm package.
-InversifyJS requires the experimentalDecorators, emitDecoratorMetadataand lib compilation options in your tsconfig.json file.
+swagger-express-ts requires the experimentalDecorators, emitDecoratorMetadata and lib compilation options in your tsconfig.json file.
 
 ```json
 {


### PR DESCRIPTION
Also had to fix a minor typo/error in `src/version/version.controller.ts` so I could get tests and the build/package step working. 

I didn't see any tests for any other definition object properties, but let me know if there are some I missed or you'd like me to make some.