### PR TITLE
Add custom tag support

### DIFF
--- a/src/lib/swagger-express-ts/i-api-operation-args.base.ts
+++ b/src/lib/swagger-express-ts/i-api-operation-args.base.ts
@@ -47,6 +47,12 @@ export interface IApiOperationArgsBase {
   consumes?: string[];
 
   /**
+   * Define consumes
+   * Optional.
+   */
+  tags?: string[];
+
+  /**
    * Define path
    * Optional.
    */

--- a/src/lib/swagger-express-ts/i-api-operation-args.base.ts
+++ b/src/lib/swagger-express-ts/i-api-operation-args.base.ts
@@ -47,7 +47,7 @@ export interface IApiOperationArgsBase {
   consumes?: string[];
 
   /**
-   * Define consumes
+   * Define tags
    * Optional.
    */
   tags?: string[];

--- a/src/lib/swagger-express-ts/swagger.service.ts
+++ b/src/lib/swagger-express-ts/swagger.service.ts
@@ -353,6 +353,10 @@ export class SwaggerService {
       operation.consumes = args.consumes;
     }
 
+    if (args.tags && args.tags.length > 0) {
+      operation.tags = args.tags;
+    }
+
     if (args.deprecated) {
       operation.deprecated = args.deprecated;
     }
@@ -623,7 +627,11 @@ export class SwaggerService {
         operation.responses
       );
     }
-    operation.tags = [_.upperFirst(controller.name)];
+    if (operation.tags && operation.tags.length > 0) {
+      operation.tags.unshift(_.upperFirst(controller.name));
+    } else {
+      operation.tags = [_.upperFirst(controller.name)];
+    }
     return operation;
   }
 


### PR DESCRIPTION
Allow to use tags for endpoint annotation. Automatic tagging based on the controller name is not overwritten, the custom tags are simply appended to the list of tags. 

Probably useful as well: Settings property to enable/disable tagging based on controller name.