### PR TITLE
BUGFIX:  Duplicate tags in generated swagger.

### DIFF
--- a/lib/swagger-express-ts-lib/src/swagger.service.ts
+++ b/lib/swagger-express-ts-lib/src/swagger.service.ts
@@ -304,10 +304,13 @@ export class SwaggerService {
                 const swaggerPath: ISwaggerPath = {};
                 data.paths[controller.path] = swaggerPath;
             }
-            data.tags.push({
-                name: _.upperFirst(controller.name),
-                description: controller.description,
-            } as ISwaggerTag);
+
+            if (!_.find(data.tags, (tag: ISwaggerTag) => tag.name === _.upperFirst(controller.name))) {
+              data.tags.push({
+                  name: _.upperFirst(controller.name),
+                  description: controller.description,
+              } as ISwaggerTag);
+            }
         }
         this.data = data;
     }


### PR DESCRIPTION
Added _.find to ensure the tag doesn't already exist in the data model before adding it.