### PR TITLE
Changed controllerMap type to an indexed object

### DIFF
--- a/lib/swagger-express-ts-lib/src/swagger.service.ts
+++ b/lib/swagger-express-ts-lib/src/swagger.service.ts
@@ -62,13 +62,13 @@ export class SwaggerService {
         return SwaggerService.instance;
     }
     private static instance: SwaggerService;
-    private controllerMap: IController[] = [];
+    private controllerMap: { [key: string]: IController } = {};
     private data: ISwagger;
     private modelsMap: { [key: string]: ISwaggerBuildDefinitionModel } = {};
     private globalResponses: { [key: string]: IApiOperationArgsBaseResponse };
 
     public resetData(): void {
-        this.controllerMap = [];
+        this.controllerMap = {};
         this.initData();
     }
 


### PR DESCRIPTION
`SwaggerService#controllerMap` being an array causes a very hard to debug bug in the rare case where the Array prototype is augmented with enumerable properties. Still controllerMap being an object seems more logical than an array and doesn't seem to cause any issues.